### PR TITLE
BN-1249  add custom bg to allow snackbar margins

### DIFF
--- a/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
+++ b/android/src/main/java/com/azendoo/reactnativesnackbar/SnackbarModule.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 public class SnackbarModule extends ReactContextBaseJavaModule {
 
     private static final String REACT_NAME = "RNSnackbar";
+    private static final int PADDING = 24;
 
     private List<Snackbar> mActiveSnackbars = new ArrayList<>();
 
@@ -129,7 +130,12 @@ public class SnackbarModule extends ReactContextBaseJavaModule {
             return;
         }
         View snackbarView = snackbar.getView();
-
+        snackbarView.getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
+        snackbarView.setPadding(PADDING, PADDING, PADDING, PADDING);
+        snackbarView.setBackground(getCurrentActivity()
+                .getResources()
+                .getDrawable(R.drawable.snackbar_background));
+        
         if (rtl && Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
             snackbarView.setLayoutDirection(View.LAYOUT_DIRECTION_RTL);
             snackbarView.setTextDirection(View.TEXT_DIRECTION_RTL);

--- a/android/src/main/res/drawable/snackbar_background.xml
+++ b/android/src/main/res/drawable/snackbar_background.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:left="8dp"
+        android:right="8dp"
+        android:bottom="8dp"
+        android:top="8dp">
+        <shape android:shape="rectangle"  >
+            <solid android:color="#212121" />
+            <corners android:radius="4dp" />
+        </shape>
+    </item>
+</layer-list>

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "flow": "flow src",
     "clean": "rm -rf lib",
     "build": "yarn run clean && babel src --out-dir lib --ignore src/__tests__",
-    "prepublish": "yarn run build"
+    "prepublish": "yarn run build",
+    "postinstall": "yarn run build && rm -rf example"
   },
   "jest": {
     "preset": "react-native",


### PR DESCRIPTION
### Purpose
We want customize the snackbar component, used in BN-1249, to have consistent visual over all the devices, 
including margins and using full screen width.